### PR TITLE
Add caching system for OCR results

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project provides both a CLI tool and a Streamlit web interface for converti
     - Option to force overwrite existing markdown files.
     - Dry run mode to preview which files will be converted or overwritten.
     - Progress bar for directory processing.
+    - Local cache to avoid re-processing identical PDFs (disable with `--no-cache`).
     - Read API key from `.env`, environment variable (`MISTRAL_API_KEY`), or command-line option.
     - Copy extracted markdown to clipboard
 - **Web Interface (Streamlit):**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "mistralai>=1.5.1",
     "pyperclip>=1.9.0",
     "python-dotenv>=1.0.1",
+    "platformdirs>=3.10.0",
     "streamlit>=1.43.1",
     "tqdm>=4.67.1",
     "typer[rich]>=0.15.2",

--- a/src/mistral_ocr/cache_utils.py
+++ b/src/mistral_ocr/cache_utils.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+"""Utilities for caching OCR results locally."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+import hashlib
+import sqlite3
+
+from platformdirs import user_cache_dir
+
+CACHE_DIR_NAME = "mistral-ocr"
+DB_NAME = "cache.db"
+
+
+@dataclass(slots=True)
+class CacheEntry:
+    """Represents a single cached OCR result."""
+
+    pdf_hash: str
+    filename: str
+    source_path: str
+    size_bytes: int
+    markdown_content: str
+    created_at: str
+    last_accessed: str
+    mistral_model: str
+
+
+class Cache:
+    """SQLite-backed cache for OCR results."""
+
+    def __init__(self, enabled: bool = True, cache_dir: Path | None = None) -> None:
+        self.enabled = enabled
+        if not enabled:
+            self.db_path = None
+            return
+        self.cache_dir = cache_dir or Path(user_cache_dir(CACHE_DIR_NAME))
+        try:
+            self.cache_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self.enabled = False
+            self.db_path = None
+            return
+        self.db_path = self.cache_dir / DB_NAME
+        self._initialize_db()
+
+    def _initialize_db(self) -> None:
+        if not self.enabled or self.db_path is None:
+            return
+        with sqlite3.connect(self.db_path, timeout=5) as conn:
+            conn.execute("PRAGMA journal_mode=WAL;")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache_entries (
+                    pdf_hash TEXT PRIMARY KEY,
+                    filename TEXT NOT NULL,
+                    source_path TEXT NOT NULL,
+                    size_bytes INTEGER NOT NULL,
+                    markdown_content TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    last_accessed TEXT NOT NULL,
+                    mistral_model TEXT NOT NULL
+                );
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_created_at ON cache_entries(created_at);"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_filename ON cache_entries(filename);"
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        assert self.db_path is not None
+        return sqlite3.connect(self.db_path, timeout=5)
+
+    def get(self, pdf_hash: str) -> CacheEntry | None:
+        if not self.enabled or self.db_path is None:
+            return None
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT * FROM cache_entries WHERE pdf_hash=?",
+                (pdf_hash,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return None
+            entry = CacheEntry(*row)
+            conn.execute(
+                "UPDATE cache_entries SET last_accessed=? WHERE pdf_hash=?",
+                (datetime.utcnow().isoformat(), pdf_hash),
+            )
+            return entry
+
+    def set(self, entry: CacheEntry) -> None:
+        if not self.enabled or self.db_path is None:
+            return
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO cache_entries (
+                    pdf_hash, filename, source_path, size_bytes,
+                    markdown_content, created_at, last_accessed, mistral_model
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    entry.pdf_hash,
+                    entry.filename,
+                    entry.source_path,
+                    entry.size_bytes,
+                    entry.markdown_content,
+                    entry.created_at,
+                    entry.last_accessed,
+                    entry.mistral_model,
+                ),
+            )
+
+    def clear(self) -> None:
+        if not self.enabled or self.db_path is None:
+            return
+        if self.db_path.exists():
+            self.db_path.unlink()
+        self._initialize_db()
+
+    def stats(self) -> dict[str, int | str]:
+        if not self.enabled or self.db_path is None:
+            return {}
+        with self._connect() as conn:
+            cur = conn.execute(
+                "SELECT COUNT(*), SUM(LENGTH(markdown_content)) FROM cache_entries"
+            )
+            total_entries, total_size = cur.fetchone()
+            cur = conn.execute(
+                "SELECT MIN(created_at), MAX(created_at) FROM cache_entries"
+            )
+            oldest, newest = cur.fetchone()
+        return {
+            "total_entries": total_entries or 0,
+            "total_size": total_size or 0,
+            "oldest": oldest or "",
+            "newest": newest or "",
+        }
+
+
+def compute_pdf_hash(file_path: Path) -> str:
+    """Compute SHA-256 hash of a PDF file."""
+    hasher = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+

--- a/src/mistral_ocr/cache_utils.py
+++ b/src/mistral_ocr/cache_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 """Utilities for caching OCR results locally."""
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 import hashlib
 import sqlite3
@@ -90,7 +90,7 @@ class Cache:
             entry = CacheEntry(*row)
             conn.execute(
                 "UPDATE cache_entries SET last_accessed=? WHERE pdf_hash=?",
-                (datetime.utcnow().isoformat(), pdf_hash),
+                (datetime.now(UTC).isoformat(), pdf_hash),
             )
             return entry
 
@@ -151,4 +151,3 @@ def compute_pdf_hash(file_path: Path) -> str:
         for chunk in iter(lambda: f.read(8192), b""):
             hasher.update(chunk)
     return hasher.hexdigest()
-

--- a/src/mistral_ocr/ocr_utils.py
+++ b/src/mistral_ocr/ocr_utils.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from datetime import datetime
+from datetime import UTC, datetime
 from pydantic import BaseModel
 
 from .cache_utils import Cache, CacheEntry, compute_pdf_hash
@@ -203,8 +203,8 @@ def process_and_save_pdf(
                 source_path=str(input_path),
                 size_bytes=input_path.stat().st_size,
                 markdown_content=markdown_content,
-                created_at=datetime.utcnow().isoformat(),
-                last_accessed=datetime.utcnow().isoformat(),
+                created_at=datetime.now(UTC).isoformat(),
+                last_accessed=datetime.now(UTC).isoformat(),
                 mistral_model="mistral-ocr-latest",
             )
             cache.set(entry)

--- a/src/mistral_ocr/ocr_utils.py
+++ b/src/mistral_ocr/ocr_utils.py
@@ -2,7 +2,10 @@
 
 import os
 from pathlib import Path
-from typing import NamedTuple
+from datetime import datetime
+from pydantic import BaseModel
+
+from .cache_utils import Cache, CacheEntry, compute_pdf_hash
 
 import pyperclip  # type: ignore[import-untyped]
 from dotenv import load_dotenv
@@ -11,12 +14,13 @@ from mistralai import Mistral, OCRResponse
 load_dotenv()
 
 
-class ProcessedDocument(NamedTuple):
+class ProcessedDocument(BaseModel):
     """Represents a successfully processed document."""
 
     filename: str
     content: str
     output_path: Path
+    from_cache: bool = False
 
 
 def initialize_mistral_client(api_key: str | None = None) -> Mistral | None:
@@ -136,7 +140,11 @@ def save_markdown_to_file(content: str, output_path: Path) -> None:
 
 
 def process_and_save_pdf(
-    client: Mistral, input_path: Path, output_dir: Path, force: bool = False
+    client: Mistral,
+    input_path: Path,
+    output_dir: Path,
+    force: bool = False,
+    cache: Cache | None = None,
 ) -> tuple[bool, str, ProcessedDocument | None]:
     """Process a single PDF file and save its markdown output.
 
@@ -160,6 +168,23 @@ def process_and_save_pdf(
                 None,
             )
 
+        pdf_hash = compute_pdf_hash(input_path)
+        if cache:
+            cached = cache.get(pdf_hash)
+            if cached:
+                save_markdown_to_file(cached.markdown_content, output_path)
+                processed_doc = ProcessedDocument(
+                    filename=input_path.name,
+                    content=cached.markdown_content,
+                    output_path=output_path,
+                    from_cache=True,
+                )
+                return (
+                    True,
+                    f"{input_path} (cached)",
+                    processed_doc,
+                )
+
         ocr_response = process_pdf_file(client, input_path)
         markdown_content = extract_markdown_from_response(ocr_response)
         save_markdown_to_file(markdown_content, output_path)
@@ -168,7 +193,21 @@ def process_and_save_pdf(
             filename=input_path.name,
             content=markdown_content,
             output_path=output_path,
+            from_cache=False,
         )
+
+        if cache:
+            entry = CacheEntry(
+                pdf_hash=pdf_hash,
+                filename=input_path.name,
+                source_path=str(input_path),
+                size_bytes=input_path.stat().st_size,
+                markdown_content=markdown_content,
+                created_at=datetime.utcnow().isoformat(),
+                last_accessed=datetime.utcnow().isoformat(),
+                mistral_model="mistral-ocr-latest",
+            )
+            cache.set(entry)
 
         return (
             True,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from datetime import datetime
+from datetime import UTC, datetime
 
 from mistral_ocr.cache_utils import Cache, CacheEntry, compute_pdf_hash
 from tests.test_utils import create_single_test_pdf
@@ -21,8 +21,8 @@ def test_cache_store_and_retrieve(tmp_path: Path) -> None:
         source_path="/tmp/a.pdf",
         size_bytes=10,
         markdown_content="content",
-        created_at=datetime.utcnow().isoformat(),
-        last_accessed=datetime.utcnow().isoformat(),
+        created_at=datetime.now(UTC).isoformat(),
+        last_accessed=datetime.now(UTC).isoformat(),
         mistral_model="test",
     )
     cache.set(entry)
@@ -39,12 +39,11 @@ def test_cache_clear(tmp_path: Path) -> None:
         source_path="/tmp/a.pdf",
         size_bytes=10,
         markdown_content="content",
-        created_at=datetime.utcnow().isoformat(),
-        last_accessed=datetime.utcnow().isoformat(),
+        created_at=datetime.now(UTC).isoformat(),
+        last_accessed=datetime.now(UTC).isoformat(),
         mistral_model="test",
     )
     cache.set(entry)
     cache.clear()
     stats = cache.stats()
     assert stats.get("total_entries", 0) == 0
-

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from datetime import datetime
+
+from mistral_ocr.cache_utils import Cache, CacheEntry, compute_pdf_hash
+from tests.test_utils import create_single_test_pdf
+
+
+def test_compute_pdf_hash_consistency(tmp_path: Path) -> None:
+    pdf = tmp_path / "test.pdf"
+    create_single_test_pdf(pdf, "hash test")
+    h1 = compute_pdf_hash(pdf)
+    h2 = compute_pdf_hash(pdf)
+    assert h1 == h2
+
+
+def test_cache_store_and_retrieve(tmp_path: Path) -> None:
+    cache = Cache(enabled=True, cache_dir=tmp_path)
+    entry = CacheEntry(
+        pdf_hash="abc",
+        filename="a.pdf",
+        source_path="/tmp/a.pdf",
+        size_bytes=10,
+        markdown_content="content",
+        created_at=datetime.utcnow().isoformat(),
+        last_accessed=datetime.utcnow().isoformat(),
+        mistral_model="test",
+    )
+    cache.set(entry)
+    loaded = cache.get("abc")
+    assert loaded is not None
+    assert loaded.markdown_content == "content"
+
+
+def test_cache_clear(tmp_path: Path) -> None:
+    cache = Cache(enabled=True, cache_dir=tmp_path)
+    entry = CacheEntry(
+        pdf_hash="abc",
+        filename="a.pdf",
+        source_path="/tmp/a.pdf",
+        size_bytes=10,
+        markdown_content="content",
+        created_at=datetime.utcnow().isoformat(),
+        last_accessed=datetime.utcnow().isoformat(),
+        mistral_model="test",
+    )
+    cache.set(entry)
+    cache.clear()
+    stats = cache.stats()
+    assert stats.get("total_entries", 0) == 0
+

--- a/uv.lock
+++ b/uv.lock
@@ -415,6 +415,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "mistralai" },
+    { name = "platformdirs" },
     { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "streamlit" },
@@ -433,6 +434,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "mistralai", specifier = ">=1.5.1" },
+    { name = "platformdirs", specifier = ">=3.10.0" },
     { name = "pyperclip", specifier = ">=1.9.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
     { name = "streamlit", specifier = ">=1.43.1" },
@@ -593,6 +595,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/92/1ca0c3f09233bd7decf8f7105a1c4e3162fb9142128c74adad0fb361b7eb/pillow-11.2.1-cp313-cp313t-win32.whl", hash = "sha256:e0b55f27f584ed623221cfe995c912c61606be8513bfa0e07d2c674b4516d9dd", size = 2335774, upload-time = "2025-04-12T17:49:04.889Z" },
     { url = "https://files.pythonhosted.org/packages/a5/ac/77525347cb43b83ae905ffe257bbe2cc6fd23acb9796639a1f56aa59d191/pillow-11.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:36d6b82164c39ce5482f649b437382c0fb2395eabc1e2b1702a6deb8ad647d6e", size = 2681895, upload-time = "2025-04-12T17:49:06.635Z" },
     { url = "https://files.pythonhosted.org/packages/67/32/32dc030cfa91ca0fc52baebbba2e009bb001122a1daa8b6a79ad830b38d3/pillow-11.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:225c832a13326e34f212d2072982bb1adb210e0cc0b153e688743018c94a2681", size = 2417234, upload-time = "2025-04-12T17:49:08.399Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add platformdirs dependency
- implement sqlite-based cache utility
- integrate caching into CLI and OCR utilities
- add unit tests for cache behavior
- document cache feature in README

## Testing
- `uv run ruff format src tests` *(fails: Request failed)*
- `uv run ruff check` *(fails: Request failed)*
- `uv run python -m pytest -q` *(fails: Request failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ea31a04948328aa53da492990049c