### PR TITLE
Add image document support to OCR CLI and app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ This project provides both a CLI tool and a Streamlit web interface for converti
 ## Features
 
 - **CLI Tool:**
-- Process single documents (PDFs or images) or entire directories.
+  - Process single documents (PDFs or images) or entire directories.
     - Specify output directory.
     - Option to force overwrite existing markdown files.
     - Dry run mode to preview which files will be converted or overwritten.
     - Progress bar for directory processing.
-- Local cache to avoid re-processing identical documents (disable with `--no-cache`).
-    - Read API key from `.env`, environment variable (`MISTRAL_API_KEY`), or command-line option.
-    - Copy extracted markdown to clipboard
+  - Local cache to avoid re-processing identical documents (disable with `--no-cache`).
+  - Read API key from `.env`, environment variable (`MISTRAL_API_KEY`), or command-line option.
+  - Copy extracted markdown to clipboard
 - **Web Interface (Streamlit):**
-- Upload local PDFs or images.
-- Process PDFs or images from URLs.
-    - Enter API key directly in the interface (also reads from `.env`/environment).
-    - View extracted markdown.
+  - Upload local PDFs or images.
+  - Process PDFs or images from URLs.
+  - Enter API key directly in the interface (also reads from `.env`/environment).
+  - View extracted markdown.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
-# Mistral OCR PDF to Markdown Converter
+# Mistral OCR Document to Markdown Converter
 
-This project provides both a CLI tool and a Streamlit web interface for converting PDF documents to Markdown format using the Mistral OCR API. It can process single files or entire directories of PDFs.
+This project provides both a CLI tool and a Streamlit web interface for converting PDFs and images to Markdown format using the Mistral OCR API. It can process single files or entire directories of supported documents.
 
 ## Features
 
 - **CLI Tool:**
-    - Process single PDF files or directories.
+- Process single documents (PDFs or images) or entire directories.
     - Specify output directory.
     - Option to force overwrite existing markdown files.
     - Dry run mode to preview which files will be converted or overwritten.
     - Progress bar for directory processing.
-    - Local cache to avoid re-processing identical PDFs (disable with `--no-cache`).
+- Local cache to avoid re-processing identical documents (disable with `--no-cache`).
     - Read API key from `.env`, environment variable (`MISTRAL_API_KEY`), or command-line option.
     - Copy extracted markdown to clipboard
 - **Web Interface (Streamlit):**
-    - Upload local PDF files.
-    - Process PDFs from URLs.
+- Upload local PDFs or images.
+- Process PDFs or images from URLs.
     - Enter API key directly in the interface (also reads from `.env`/environment).
     - View extracted markdown.
 
@@ -71,10 +71,10 @@ uv run mistral-ocr --help
 
 # --- Examples ---
 
-# Convert a single PDF file (output to same directory)
+# Convert a single document (output to same directory)
 mistral-ocr path/to/your/document.pdf
 
-# Convert a directory of PDFs (output to same directory)
+# Convert a directory of documents (output to same directory)
 mistral-ocr path/to/pdf_folder/
 
 # Specify output directory

--- a/src/mistral_ocr/__init__.py
+++ b/src/mistral_ocr/__init__.py
@@ -1,4 +1,4 @@
-"""CLI interface for Mistral OCR PDF to Markdown converter."""
+"""CLI interface for Mistral OCR document (PDF/image) to Markdown converter."""
 
 from pathlib import Path
 from typing import Annotated, Literal
@@ -11,22 +11,25 @@ from rich.console import Console
 from tqdm import tqdm
 
 from .ocr_utils import (
-    initialize_mistral_client,
-    process_and_save_pdf,
-    handle_clipboard_operation,
     ProcessedDocument,
+    detect_document_kind_from_path,
+    handle_clipboard_operation,
+    initialize_mistral_client,
+    process_and_save_document,
 )
 from .cache_utils import Cache
 
-app = typer.Typer(help="Convert PDF files to Markdown using Mistral OCR")
+app = typer.Typer(
+    help="Convert documents (PDFs and images) to Markdown using Mistral OCR"
+)
 console = Console()
 
 
 class FileAction(BaseModel):
-    """Represents a planned action for a single PDF file.
+    """Represents a planned action for a single document.
 
     Attributes:
-        input_path: The PDF file to process
+        input_path: The document to process
         output_path: Where the markdown output will be saved
         action: Whether to convert the file or skip it
         will_overwrite: True if converting will overwrite an existing file
@@ -146,7 +149,7 @@ def validate_conversion_plan(plan: ConversionPlan) -> ValidationResult:
             is_valid=False,
             errors=[
                 ValidationError(
-                    message=f"No PDF files found in the input path.",
+                    message="No supported documents found in the input path.",
                     error_code=0,  # Warning, not error
                 )
             ],
@@ -155,105 +158,85 @@ def validate_conversion_plan(plan: ConversionPlan) -> ValidationResult:
     return ValidationResult(is_valid=True)
 
 
-def is_pdf_file(file_path: Path) -> bool:
-    """Check if a file is a PDF file.
+def is_supported_document(file_path: Path) -> bool:
+    """Check whether a path points to a supported document type."""
 
-    Args:
-        file_path: Path to check
-
-    Returns:
-        True if the file has a .pdf extension
-    """
-    return file_path.suffix.lower() == ".pdf"
+    return detect_document_kind_from_path(file_path) is not None
 
 
-def find_pdf_files_pure(input_path: Path) -> tuple[list[Path], list[str]]:
-    """Find all PDF files in the given path, returning both files and warnings.
+def find_supported_documents_pure(
+    input_path: Path,
+) -> tuple[list[Path], list[str]]:
+    """Find supported documents in the given path, returning files and warnings."""
 
-    Args:
-        input_path: Path to search for PDF files
-
-    Returns:
-        Tuple of (pdf_files, warnings)
-    """
     warnings: list[str] = []
 
     if input_path.is_file():
-        if is_pdf_file(input_path):
+        if is_supported_document(input_path):
             return [input_path], warnings
-        else:
-            warnings.append(f"Warning: {input_path} is not a PDF file")
-            return [], warnings
+        warnings.append(f"Warning: {input_path} is not a supported document")
+        return [], warnings
 
     if input_path.is_dir():
-        pdf_files = list(input_path.glob("**/*.pdf"))
-        return pdf_files, warnings
+        documents = [
+            candidate
+            for candidate in input_path.rglob("*")
+            if candidate.is_file() and is_supported_document(candidate)
+        ]
+        return documents, warnings
 
     return [], warnings
 
 
-def find_pdf_files(input_path: Path) -> list[Path]:
-    """Find all PDF files in the given path.
+def find_supported_documents(input_path: Path) -> list[Path]:
+    """Find all supported document files in the given path."""
 
-    Args:
-        input_path: Path to search for PDF files
+    documents, warnings = find_supported_documents_pure(input_path)
 
-    Returns:
-        List of PDF file paths
-    """
-    pdf_files, warnings = find_pdf_files_pure(input_path)
-
-    # Handle side effects
     for warning in warnings:
         console.print(f"[yellow]{warning}[/yellow]")
 
-    return pdf_files
+    return documents
 
 
-def process_pdf_files(
+def process_documents(
     client: Mistral,
-    pdf_files: list[Path],
+    document_paths: list[Path],
     output_dir: Path,
     force: bool,
     cache: Cache | None,
     show_progress: bool = True,
 ) -> list[tuple[bool, str, ProcessedDocument | None]]:
-    """Process multiple PDF files.
+    """Process multiple supported documents."""
 
-    Args:
-        client: Initialized Mistral client
-        pdf_files: List of PDF files to process
-        output_dir: Output directory for markdown files
-        force: Whether to overwrite existing files
-        show_progress: Whether to show progress bar
-
-    Returns:
-        List of processing results
-    """
-    if not pdf_files:
-        console.print("[yellow]No PDF files found to process[/yellow]")
+    if not document_paths:
+        console.print("[yellow]No supported documents found to process[/yellow]")
         return []
 
     results: list[tuple[bool, str, ProcessedDocument | None]] = []
-    iterator = pdf_files
+    iterator = document_paths
 
-    if show_progress and len(pdf_files) > 1:
-        iterator = tqdm(pdf_files, desc="Processing PDFs")
+    if show_progress and len(document_paths) > 1:
+        iterator = tqdm(document_paths, desc="Processing documents")
 
-    for pdf_file in iterator:
-        if show_progress and len(pdf_files) > 1:
+    for document_path in iterator:
+        if show_progress and len(document_paths) > 1:
             if isinstance(iterator, tqdm):
-                iterator.set_description(f"Processing {pdf_file.name}")  # type: ignore
+                iterator.set_description(  # type: ignore[attr-defined]
+                    f"Processing {document_path.name}"
+                )
 
-        result = process_and_save_pdf(client, pdf_file, output_dir, force, cache)
+        result = process_and_save_document(
+            client, document_path, output_dir, force, cache
+        )
         results.append(result)
         success, message, doc = result
         if success and doc and doc.from_cache:
-            console.print(f"✓ {pdf_file.name} (cached)")
+            console.print(f"✓ {document_path.name} (cached)")
         elif success:
-            console.print(f"⟳ {pdf_file.name} (processing...)")
+            console.print(f"⟳ {document_path.name} (processing...)")
         else:
-            console.print(f"✗ {pdf_file.name}: {message}")
+            console.print(f"✗ {document_path.name}: {message}")
 
     return results
 
@@ -311,11 +294,13 @@ def determine_output_directory(
         return input_path.parent
 
 
-def calculate_output_path(pdf_file: Path, input_path: Path, output_dir: Path) -> Path:
-    """Calculate the output path for a PDF file.
+def calculate_output_path(
+    document_path: Path, input_path: Path, output_dir: Path
+) -> Path:
+    """Calculate the output path for a document.
 
     Args:
-        pdf_file: The PDF file to process
+        document_path: The document to process
         input_path: The original input path (file or directory)
         output_dir: The resolved output directory
 
@@ -324,19 +309,19 @@ def calculate_output_path(pdf_file: Path, input_path: Path, output_dir: Path) ->
     """
     if input_path.is_dir():
         # Preserve directory structure: compute path relative to input directory
-        rel_pdf = pdf_file.relative_to(input_path)
+        rel_pdf = document_path.relative_to(input_path)
         rel_md = rel_pdf.with_suffix(".md")
         return output_dir / rel_md
     else:
         # Single file: place at root of output directory
-        return output_dir / f"{pdf_file.stem}.md"
+        return output_dir / f"{document_path.stem}.md"
 
 
-def create_file_action(pdf_file: Path, output_path: Path, force: bool) -> FileAction:
+def create_file_action(document_path: Path, output_path: Path, force: bool) -> FileAction:
     """Create a file action based on whether the output file exists.
 
     Args:
-        pdf_file: The PDF file to process
+        document_path: The document to process
         output_path: The calculated output path
         force: Whether to overwrite existing files
 
@@ -346,14 +331,14 @@ def create_file_action(pdf_file: Path, output_path: Path, force: bool) -> FileAc
     if output_path.exists():
         if force:
             return FileAction(
-                input_path=pdf_file,
+                input_path=document_path,
                 output_path=output_path,
                 action="convert",
                 will_overwrite=True,
             )
         else:
             return FileAction(
-                input_path=pdf_file,
+                input_path=document_path,
                 output_path=output_path,
                 action="skip",
                 will_overwrite=False,
@@ -361,7 +346,7 @@ def create_file_action(pdf_file: Path, output_path: Path, force: bool) -> FileAc
             )
     else:
         return FileAction(
-            input_path=pdf_file,
+            input_path=document_path,
             output_path=output_path,
             action="convert",
             will_overwrite=False,
@@ -369,29 +354,19 @@ def create_file_action(pdf_file: Path, output_path: Path, force: bool) -> FileAc
 
 
 def create_conversion_plan_pure(
-    pdf_files: list[Path],
+    document_paths: list[Path],
     input_path: Path,
     output_dir: Path,
     force: bool,
     clipboard: bool,
 ) -> ConversionPlan:
-    """Create a conversion plan from a list of PDF files (pure function).
+    """Create a conversion plan from supported documents (pure function)."""
 
-    Args:
-        pdf_files: List of PDF files to process
-        input_path: Original input path
-        output_dir: Resolved output directory
-        force: Whether to overwrite existing files
-        clipboard: Whether to copy to clipboard
-
-    Returns:
-        ConversionPlan describing what actions to take
-    """
     actions: list[FileAction] = []
 
-    for pdf_file in pdf_files:
-        output_path = calculate_output_path(pdf_file, input_path, output_dir)
-        action = create_file_action(pdf_file, output_path, force)
+    for document_path in document_paths:
+        output_path = calculate_output_path(document_path, input_path, output_dir)
+        action = create_file_action(document_path, output_path, force)
         actions.append(action)
 
     return ConversionPlan(
@@ -411,10 +386,10 @@ def create_conversion_plan(
     """Create a plan describing what actions will be taken."""
 
     resolved_output_dir = determine_output_directory(input_path, output_dir)
-    pdf_files = find_pdf_files(input_path)
+    document_paths = find_supported_documents(input_path)
 
     return create_conversion_plan_pure(
-        pdf_files=pdf_files,
+        document_paths=document_paths,
         input_path=input_path,
         output_dir=resolved_output_dir,
         force=force,
@@ -425,7 +400,10 @@ def create_conversion_plan(
 @app.command()
 def convert(
     input_path: Annotated[
-        Path, typer.Argument(help="Path to PDF file or directory containing PDFs")
+        Path,
+        typer.Argument(
+            help="Path to a document file or directory containing PDFs or images"
+        ),
     ],
     output_dir: Annotated[
         Path | None,
@@ -472,7 +450,7 @@ def convert(
         typer.Option("--cache-stats", help="Show cache statistics and exit"),
     ] = False,
 ) -> None:
-    """Convert PDF files to Markdown using Mistral OCR."""
+    """Convert documents to Markdown using Mistral OCR."""
     # Validate input path
     input_validation = validate_input_path(input_path)
     if not input_validation.is_valid:
@@ -589,10 +567,10 @@ def convert(
         )
 
     try:
-        pdf_files_to_process = [a.input_path for a in plan.files if a.is_converting]
-        results = process_pdf_files(
+        documents_to_process = [a.input_path for a in plan.files if a.is_converting]
+        results = process_documents(
             client,
-            pdf_files_to_process,
+            documents_to_process,
             plan.output_dir,
             plan.force,
             cache,

--- a/src/mistral_ocr/app.py
+++ b/src/mistral_ocr/app.py
@@ -1,4 +1,4 @@
-"""Streamlit web interface for Mistral OCR PDF to Markdown converter."""
+"""Streamlit web interface for Mistral OCR document to Markdown converter."""
 
 import os
 
@@ -7,55 +7,35 @@ from dotenv import load_dotenv
 from mistralai import Mistral, OCRResponse
 
 from mistral_ocr.ocr_utils import (
-    initialize_mistral_client,
-    process_pdf_url,
     extract_markdown_from_response,
+    initialize_mistral_client,
+    process_document_bytes,
+    process_document_url,
 )
 
 load_dotenv()
 
 
-def process_uploaded_pdf(
+def process_uploaded_document(
     client: Mistral,
     file_content: bytes,
-    file_name: str = "uploaded.pdf",
+    file_name: str,
     include_image_base64: bool = False,
 ) -> OCRResponse | None:
-    """Process uploaded PDF file and return OCR results.
+    """Process an uploaded PDF or image and return OCR results."""
 
-    Args:
-        client: Initialized Mistral client
-        file_content: PDF file content as bytes
-        file_name: Name of the uploaded file
-        include_image_base64: Whether to include base64 encoded images
-
-    Returns:
-        OCR response or None if processing failed
-    """
     try:
-        # Upload the file
-        uploaded_pdf = client.files.upload(
-            file={
-                "file_name": file_name,
-                "content": file_content,
-            },
-            purpose="ocr",
-        )
-
-        # Get signed URL
-        signed_url = client.files.get_signed_url(file_id=uploaded_pdf.id)
-
-        # Process OCR
-        return client.ocr.process(
-            model="mistral-ocr-latest",
-            document={
-                "type": "document_url",
-                "document_url": signed_url.url,
-            },
+        return process_document_bytes(
+            client,
+            file_content,
+            file_name,
             include_image_base64=include_image_base64,
         )
-    except Exception as e:
-        st.error(f"Error processing uploaded file: {e}")
+    except ValueError as exc:
+        st.error(str(exc))
+        return None
+    except Exception as exc:
+        st.error(f"Error processing uploaded file: {exc}")
         return None
 
 
@@ -106,16 +86,12 @@ def initialize_client_with_key(api_key: str) -> Mistral | None:
 
 
 def handle_file_upload(client: Mistral) -> OCRResponse | None:
-    """Handle PDF file upload and processing.
+    """Handle document upload and processing."""
 
-    Args:
-        client: Initialized Mistral client
-
-    Returns:
-        OCR response or None if no file uploaded or processing failed
-    """
     uploaded_file = st.file_uploader(
-        "Choose a PDF file", type="pdf", label_visibility="collapsed"
+        "Choose a document",
+        type=["pdf", "png", "jpg", "jpeg", "webp", "bmp", "tif", "tiff"],
+        label_visibility="collapsed",
     )
 
     if not uploaded_file:
@@ -124,33 +100,29 @@ def handle_file_upload(client: Mistral) -> OCRResponse | None:
     if st.button(
         "Convert Uploaded File", use_container_width=True, key="convert_upload"
     ):
-        with st.spinner("Processing uploaded PDF..."):
+        with st.spinner("Processing uploaded document..."):
             file_content = uploaded_file.getvalue()
-            return process_uploaded_pdf(client, file_content, uploaded_file.name)
+            return process_uploaded_document(client, file_content, uploaded_file.name)
 
     return None
 
 
 def handle_url_input(client: Mistral) -> OCRResponse | None:
-    """Handle PDF URL input and processing.
+    """Handle URL input and processing for PDFs or images."""
 
-    Args:
-        client: Initialized Mistral client
+    document_url = st.text_input(
+        "Enter document URL", label_visibility="collapsed"
+    )
 
-    Returns:
-        OCR response or None if no URL provided or processing failed
-    """
-    pdf_url = st.text_input("Enter PDF URL", label_visibility="collapsed")
-
-    if not pdf_url:
+    if not document_url:
         return None
 
     if st.button("Convert URL", use_container_width=True, key="convert_url"):
-        with st.spinner("Processing PDF from URL..."):
+        with st.spinner("Processing document from URL..."):
             try:
-                return process_pdf_url(client, pdf_url)
-            except Exception as e:
-                st.error(f"Error processing URL: {e}")
+                return process_document_url(client, document_url)
+            except Exception as exc:
+                st.error(f"Error processing URL: {exc}")
                 return None
 
     return None
@@ -162,13 +134,13 @@ def show_placeholder_message() -> None:
         "convert_upload" not in st.session_state
         and "convert_url" not in st.session_state
     ):
-        st.info("Upload a PDF or enter a URL and click Convert.")
+        st.info("Upload a document or enter a URL and click Convert.")
 
 
 def run_app() -> None:
     """Run the Streamlit application."""
     st.set_page_config(layout="wide")
-    st.title("📄 Mistral PDF to Markdown Converter")
+    st.title("📄 Mistral Document to Markdown Converter")
 
     # Configuration sidebar
     st.sidebar.header("Configuration")
@@ -192,11 +164,11 @@ def run_app() -> None:
     ocr_result = None
 
     with col1:
-        st.subheader("⬆️ Upload PDF File")
+        st.subheader("⬆️ Upload Document")
         ocr_result = handle_file_upload(client) or ocr_result
 
     with col2:
-        st.subheader("🔗 Enter PDF URL")
+        st.subheader("🔗 Enter Document URL")
         ocr_result = handle_url_input(client) or ocr_result
 
     # Display results

--- a/src/mistral_ocr/cache_utils.py
+++ b/src/mistral_ocr/cache_utils.py
@@ -144,8 +144,8 @@ class Cache:
         }
 
 
-def compute_pdf_hash(file_path: Path) -> str:
-    """Compute SHA-256 hash of a PDF file."""
+def compute_file_hash(file_path: Path) -> str:
+    """Compute SHA-256 hash of a file."""
     hasher = hashlib.sha256()
     with open(file_path, "rb") as f:
         for chunk in iter(lambda: f.read(8192), b""):

--- a/src/mistral_ocr/ocr_utils.py
+++ b/src/mistral_ocr/ocr_utils.py
@@ -1,11 +1,15 @@
 """Utility functions for OCR processing and file operations."""
 
+import base64
 import os
+from enum import Enum
 from pathlib import Path
+from urllib.parse import urlparse
 from datetime import UTC, datetime
+from typing import Final
 from pydantic import BaseModel
 
-from .cache_utils import Cache, CacheEntry, compute_pdf_hash
+from .cache_utils import Cache, CacheEntry, compute_file_hash
 
 import pyperclip  # type: ignore[import-untyped]
 from dotenv import load_dotenv
@@ -21,6 +25,48 @@ class ProcessedDocument(BaseModel):
     content: str
     output_path: Path
     from_cache: bool = False
+
+
+class DocumentKind(str, Enum):
+    """Supported document types for OCR."""
+
+    PDF = "pdf"
+    IMAGE = "image"
+
+
+IMAGE_MIME_TYPES: Final[dict[str, str]] = {
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".webp": "image/webp",
+    ".bmp": "image/bmp",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+}
+
+SUPPORTED_SUFFIXES: Final[dict[str, DocumentKind]] = {
+    ".pdf": DocumentKind.PDF,
+    **{suffix: DocumentKind.IMAGE for suffix in IMAGE_MIME_TYPES},
+}
+
+
+def detect_document_kind_from_suffix(suffix: str) -> DocumentKind | None:
+    """Return the document kind for a given file suffix."""
+
+    return SUPPORTED_SUFFIXES.get(suffix.lower())
+
+
+def detect_document_kind_from_path(path: Path) -> DocumentKind | None:
+    """Determine document kind from a filesystem path."""
+
+    return detect_document_kind_from_suffix(path.suffix)
+
+
+def detect_document_kind_from_url(url: str) -> DocumentKind | None:
+    """Determine document kind from a URL."""
+
+    parsed = urlparse(url)
+    return detect_document_kind_from_suffix(Path(parsed.path).suffix)
 
 
 def initialize_mistral_client(api_key: str | None = None) -> Mistral | None:
@@ -41,68 +87,52 @@ def initialize_mistral_client(api_key: str | None = None) -> Mistral | None:
     return Mistral(api_key=api_key)
 
 
-def process_pdf_url(
+def build_document_payload_for_url(url: str) -> dict[str, str]:
+    """Build the document payload for a remote resource."""
+
+    kind = detect_document_kind_from_url(url)
+    if kind is DocumentKind.IMAGE:
+        return {"type": "image_url", "image_url": url}
+    return {"type": "document_url", "document_url": url}
+
+
+def process_document_url(
     client: Mistral, url: str, include_image_base64: bool = False
 ) -> OCRResponse:
-    """Process PDF from URL and return OCR results.
+    """Process a remote document (PDF or image) and return OCR results."""
 
-    Args:
-        client: Initialized Mistral client
-        url: URL of the PDF to process
-        include_image_base64: Whether to include base64 encoded images
-
-    Returns:
-        OCR response from Mistral API
-
-    Raises:
-        Exception: If processing fails
-    """
     return client.ocr.process(
         model="mistral-ocr-latest",
-        document={"type": "document_url", "document_url": url},
+        document=build_document_payload_for_url(url),
         include_image_base64=include_image_base64,
     )
 
 
-def process_pdf_file(
-    client: Mistral,
-    file_path: Path,
-    include_image_base64: bool = False,
+def _process_pdf_file(
+    client: Mistral, file_path: Path, include_image_base64: bool
 ) -> OCRResponse:
-    """Process PDF file and return OCR results.
-
-    Args:
-        client: Initialized Mistral client
-        file_path: Path to the PDF file
-        include_image_base64: Whether to include base64 encoded images
-
-    Returns:
-        OCR response from Mistral API
-
-    Raises:
-        FileNotFoundError: If file doesn't exist
-        Exception: If processing fails
-    """
     if not file_path.exists():
         raise FileNotFoundError(f"File not found: {file_path}")
 
-    # Read file content
     with open(file_path, "rb") as f:
         file_content = f.read()
 
-    # Upload the file
+    return _process_pdf_bytes(client, file_content, file_path.name, include_image_base64)
+
+
+def _process_pdf_bytes(
+    client: Mistral, file_content: bytes, file_name: str, include_image_base64: bool
+) -> OCRResponse:
     uploaded_pdf = client.files.upload(
         file={
-            "file_name": file_path.name,
+            "file_name": file_name,
             "content": file_content,
         },
         purpose="ocr",
     )
 
-    # Get signed URL
     signed_url = client.files.get_signed_url(file_id=uploaded_pdf.id)
 
-    # Process OCR
     return client.ocr.process(
         model="mistral-ocr-latest",
         document={
@@ -111,6 +141,79 @@ def process_pdf_file(
         },
         include_image_base64=include_image_base64,
     )
+
+
+def _process_image_file(
+    client: Mistral, file_path: Path, include_image_base64: bool
+) -> OCRResponse:
+    if not file_path.exists():
+        raise FileNotFoundError(f"File not found: {file_path}")
+
+    mime_type = IMAGE_MIME_TYPES.get(file_path.suffix.lower())
+    if not mime_type:
+        raise ValueError(f"Unsupported image format: {file_path.suffix}")
+
+    with open(file_path, "rb") as f:
+        file_content = f.read()
+
+    return _process_image_bytes(client, file_content, file_path.suffix, include_image_base64)
+
+
+def _process_image_bytes(
+    client: Mistral,
+    file_content: bytes,
+    suffix: str,
+    include_image_base64: bool,
+) -> OCRResponse:
+    mime_type = IMAGE_MIME_TYPES.get(suffix.lower())
+    if not mime_type:
+        raise ValueError(f"Unsupported image format: {suffix}")
+
+    base64_content = base64.b64encode(file_content).decode("utf-8")
+    data_url = f"data:{mime_type};base64,{base64_content}"
+
+    return client.ocr.process(
+        model="mistral-ocr-latest",
+        document={
+            "type": "image_url",
+            "image_url": data_url,
+        },
+        include_image_base64=include_image_base64,
+    )
+
+
+def process_document_file(
+    client: Mistral,
+    file_path: Path,
+    include_image_base64: bool = False,
+) -> OCRResponse:
+    """Process a local PDF or image file and return OCR results."""
+
+    kind = detect_document_kind_from_path(file_path)
+    if kind is None:
+        raise ValueError(f"Unsupported file type for OCR: {file_path.suffix}")
+
+    if kind is DocumentKind.PDF:
+        return _process_pdf_file(client, file_path, include_image_base64)
+    return _process_image_file(client, file_path, include_image_base64)
+
+
+def process_document_bytes(
+    client: Mistral,
+    file_content: bytes,
+    file_name: str,
+    include_image_base64: bool = False,
+) -> OCRResponse:
+    """Process in-memory document bytes and return OCR results."""
+
+    suffix = Path(file_name).suffix
+    kind = detect_document_kind_from_suffix(suffix)
+    if kind is None:
+        raise ValueError(f"Unsupported file type for OCR: {suffix}")
+
+    if kind is DocumentKind.PDF:
+        return _process_pdf_bytes(client, file_content, file_name, include_image_base64)
+    return _process_image_bytes(client, file_content, suffix, include_image_base64)
 
 
 def extract_markdown_from_response(ocr_response: OCRResponse) -> str:
@@ -139,25 +242,15 @@ def save_markdown_to_file(content: str, output_path: Path) -> None:
     output_path.write_text(content, encoding="utf-8")
 
 
-def process_and_save_pdf(
+def process_and_save_document(
     client: Mistral,
     input_path: Path,
     output_dir: Path,
     force: bool = False,
     cache: Cache | None = None,
 ) -> tuple[bool, str, ProcessedDocument | None]:
-    """Process a single PDF file and save its markdown output.
+    """Process a single document and save its markdown output."""
 
-    Args:
-        client: Initialized Mistral client
-        input_path: Path to the PDF file
-        output_dir: Directory to save the markdown file
-        force: Whether to overwrite existing files
-
-    Returns:
-        Tuple of (success, message, processed_document)
-        processed_document is None if processing failed
-    """
     try:
         output_path = output_dir / f"{input_path.stem}.md"
 
@@ -168,9 +261,9 @@ def process_and_save_pdf(
                 None,
             )
 
-        pdf_hash = compute_pdf_hash(input_path)
+        document_hash = compute_file_hash(input_path)
         if cache:
-            cached = cache.get(pdf_hash)
+            cached = cache.get(document_hash)
             if cached:
                 save_markdown_to_file(cached.markdown_content, output_path)
                 processed_doc = ProcessedDocument(
@@ -185,7 +278,7 @@ def process_and_save_pdf(
                     processed_doc,
                 )
 
-        ocr_response = process_pdf_file(client, input_path)
+        ocr_response = process_document_file(client, input_path)
         markdown_content = extract_markdown_from_response(ocr_response)
         save_markdown_to_file(markdown_content, output_path)
 
@@ -198,7 +291,7 @@ def process_and_save_pdf(
 
         if cache:
             entry = CacheEntry(
-                pdf_hash=pdf_hash,
+                pdf_hash=document_hash,
                 filename=input_path.name,
                 source_path=str(input_path),
                 size_bytes=input_path.stat().st_size,

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,15 +1,15 @@
 from pathlib import Path
 from datetime import UTC, datetime
 
-from mistral_ocr.cache_utils import Cache, CacheEntry, compute_pdf_hash
+from mistral_ocr.cache_utils import Cache, CacheEntry, compute_file_hash
 from tests.test_utils import create_single_test_pdf
 
 
-def test_compute_pdf_hash_consistency(tmp_path: Path) -> None:
+def test_compute_file_hash_consistency(tmp_path: Path) -> None:
     pdf = tmp_path / "test.pdf"
     create_single_test_pdf(pdf, "hash test")
-    h1 = compute_pdf_hash(pdf)
-    h2 = compute_pdf_hash(pdf)
+    h1 = compute_file_hash(pdf)
+    h2 = compute_file_hash(pdf)
     assert h1 == h2
 
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+from mistral_ocr import (
+    create_conversion_plan_pure,
+    find_supported_documents_pure,
+    is_supported_document,
+)
+
+
+def test_is_supported_document_accepts_pdf_and_image(tmp_path: Path) -> None:
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"")
+    image = tmp_path / "image.png"
+    image.write_bytes(b"")
+
+    assert is_supported_document(pdf) is True
+    assert is_supported_document(image) is True
+
+
+def test_find_supported_documents_in_directory(tmp_path: Path) -> None:
+    pdf = tmp_path / "docs" / "a.pdf"
+    pdf.parent.mkdir(parents=True, exist_ok=True)
+    pdf.write_bytes(b"")
+    image = tmp_path / "docs" / "b.jpeg"
+    image.write_bytes(b"")
+    other = tmp_path / "docs" / "notes.txt"
+    other.write_text("ignore")
+
+    documents, warnings = find_supported_documents_pure(tmp_path / "docs")
+
+    assert set(documents) == {pdf, image}
+    assert warnings == []
+
+
+def test_find_supported_documents_warns_on_single_file(tmp_path: Path) -> None:
+    unsupported = tmp_path / "report.txt"
+    unsupported.write_text("unsupported")
+
+    documents, warnings = find_supported_documents_pure(unsupported)
+
+    assert documents == []
+    assert warnings == [f"Warning: {unsupported} is not a supported document"]
+
+
+def test_create_conversion_plan_pure_uses_documents(tmp_path: Path) -> None:
+    pdf = tmp_path / "a.pdf"
+    pdf.write_bytes(b"")
+    image = tmp_path / "b.png"
+    image.write_bytes(b"")
+    output_dir = tmp_path / "out"
+
+    plan = create_conversion_plan_pure(
+        document_paths=[pdf, image],
+        input_path=tmp_path,
+        output_dir=output_dir,
+        force=False,
+        clipboard=False,
+    )
+
+    assert [action.input_path for action in plan.files] == [pdf, image]


### PR DESCRIPTION
## Summary
- extend the OCR utilities to detect PDFs and common image formats, allowing in-memory and file-based processing of either type
- update the CLI planning and processing pipeline along with the Streamlit UI to accept image uploads/URLs alongside PDFs and refresh documentation accordingly
- add unit coverage for the new document discovery helpers

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68fe245a298c8328a44844894ba2da7c